### PR TITLE
fix: stop lua pattern-matching

### DIFF
--- a/lua/opposites/opposite.lua
+++ b/lua/opposites/opposite.lua
@@ -36,7 +36,7 @@ local M = {}
 ---@return integer # The index of the beginning of the word or `-1` if not found.
 local function find_word_in_line(line, col, word)
   local min_idx = (col + 1) - (#word - 1)
-  local idx = string.find(line, word, min_idx)
+  local idx = string.find(line, word, min_idx, true)
   return idx ~= nil and idx <= (col + 1) and idx or -1
 end
 


### PR DESCRIPTION
https://www.lua.org/manual/5.1/manual.html#pdf-string.find
> A value of true as a fourth, optional argument `plain`
> turns off the pattern matching facilities

Without this, I was getting errors because my config included
`        ["[["] = "]]",`
and the lua pattern matching engine got upset that "[[" was unbalanced

---

nice plugin! I especially like the case handling